### PR TITLE
Fix auto-sync toggle and add application settings foundation

### DIFF
--- a/mock-server.js
+++ b/mock-server.js
@@ -29,6 +29,7 @@ let applications = [
           namespace: 'argocd',
         },
         spec: {
+          project: 'default',
           source: {
             repoURL: 'https://github.com/argoproj/argocd-example-apps',
             path: 'guestbook',
@@ -37,6 +38,9 @@ let applications = [
           destination: {
             server: 'https://kubernetes.default.svc',
             namespace: 'default',
+          },
+          syncPolicy: {
+            automated: null,
           },
         },
         status: {
@@ -54,6 +58,7 @@ let applications = [
           namespace: 'argocd',
         },
         spec: {
+          project: 'default',
           source: {
             repoURL: 'https://github.com/argoproj/argocd-example-apps',
             path: 'helm-guestbook',
@@ -100,31 +105,14 @@ app.post('/api/v1/applications', (req, res) => {
 // Mock application detail endpoint
 app.get('/api/v1/applications/:name', (req, res) => {
   const { name } = req.params
+  const app = applications.find(a => a.metadata.name === name)
 
-  res.json({
-    metadata: {
-      name,
-      namespace: 'argocd',
-    },
-    spec: {
-      source: {
-        repoURL: 'https://github.com/argoproj/argocd-example-apps',
-        path: 'guestbook',
-        targetRevision: 'HEAD',
-      },
-      destination: {
-        server: 'https://kubernetes.default.svc',
-        namespace: 'default',
-      },
-    },
-    status: {
-      sync: {
-        status: 'Synced',
-      },
-      health: {
-        status: 'Healthy',
-      },
-      resources: [
+  if (app) {
+    res.json({
+      ...app,
+      status: {
+        ...app.status,
+        resources: [
         {
           kind: 'Service',
           name: 'guestbook-ui',
@@ -140,50 +128,70 @@ app.get('/api/v1/applications/:name', (req, res) => {
           health: { status: 'Healthy' },
         },
       ],
-      history: [
-        {
-          id: 3,
-          revision: 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0',
-          deployedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
-          deployStartedAt: new Date(Date.now() - 2 * 60 * 60 * 1000 - 30000).toISOString(),
-          initiatedBy: {
-            username: 'admin',
-            automated: false,
+        history: [
+          {
+            id: 3,
+            revision: 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0',
+            deployedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(), // 2 hours ago
+            deployStartedAt: new Date(Date.now() - 2 * 60 * 60 * 1000 - 30000).toISOString(),
+            initiatedBy: {
+              username: 'admin',
+              automated: false,
+            },
           },
-        },
-        {
-          id: 2,
-          revision: 'b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1',
-          deployedAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // 1 day ago
-          deployStartedAt: new Date(Date.now() - 24 * 60 * 60 * 1000 - 45000).toISOString(),
-          initiatedBy: {
-            username: 'system',
-            automated: true,
+          {
+            id: 2,
+            revision: 'b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1',
+            deployedAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // 1 day ago
+            deployStartedAt: new Date(Date.now() - 24 * 60 * 60 * 1000 - 45000).toISOString(),
+            initiatedBy: {
+              username: 'system',
+              automated: true,
+            },
           },
-        },
-        {
-          id: 1,
-          revision: 'c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2',
-          deployedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days ago
-          deployStartedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000 - 60000).toISOString(),
-          initiatedBy: {
-            username: 'developer',
-            automated: false,
+          {
+            id: 1,
+            revision: 'c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2',
+            deployedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days ago
+            deployStartedAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000 - 60000).toISOString(),
+            initiatedBy: {
+              username: 'developer',
+              automated: false,
+            },
           },
-        },
-        {
-          id: 0,
-          revision: 'd4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3',
-          deployedAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString(), // 14 days ago
-          deployStartedAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000 - 90000).toISOString(),
-          initiatedBy: {
-            username: 'admin',
-            automated: false,
+          {
+            id: 0,
+            revision: 'd4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3',
+            deployedAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString(), // 14 days ago
+            deployStartedAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000 - 90000).toISOString(),
+            initiatedBy: {
+              username: 'admin',
+              automated: false,
+            },
           },
-        },
-      ],
-    },
-  })
+        ],
+      },
+    })
+  } else {
+    res.status(404).json({ error: 'Application not found' })
+  }
+})
+
+// Mock application spec update endpoint
+app.put('/api/v1/applications/:name/spec', (req, res) => {
+  const { name } = req.params
+  const app = applications.find(a => a.metadata.name === name)
+
+  if (app) {
+    // Update the spec
+    app.spec = req.body
+
+    console.log(`Updated spec for ${name}:`, JSON.stringify(req.body, null, 2))
+
+    res.json(app.spec)
+  } else {
+    res.status(404).json({ error: 'Application not found' })
+  }
 })
 
 // Mock resource tree endpoint

--- a/src/pages/application-detail.tsx
+++ b/src/pages/application-detail.tsx
@@ -34,7 +34,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { useApplication, useUpdateApplication, useSyncApplication, useDeleteApplication, useRefreshApplication, useResourceTree, useManagedResources, useResource } from '@/services/applications'
+import { useApplication, useUpdateApplicationSpec, useSyncApplication, useDeleteApplication, useRefreshApplication, useResourceTree, useManagedResources, useResource } from '@/services/applications'
 import { ResourceDetailsPanel } from '@/components/resource-details-panel'
 import { ResourceDiffPanel } from '@/components/resource-diff-panel'
 import { ResourceTree } from '@/components/resource-tree'
@@ -203,7 +203,7 @@ export function ApplicationDetailPage() {
   )
 
   const syncMutation = useSyncApplication()
-  const updateMutation = useUpdateApplication()
+  const updateSpecMutation = useUpdateApplicationSpec()
   const deleteMutation = useDeleteApplication()
   const refreshMutation = useRefreshApplication()
 
@@ -240,24 +240,22 @@ export function ApplicationDetailPage() {
   const handleToggleAutoSync = async (checked: boolean) => {
     if (!name || !app) return
     try {
-      await updateMutation.mutateAsync({
+      await updateSpecMutation.mutateAsync({
         name,
-        app: {
-          spec: {
-            ...app.spec,
-            syncPolicy: checked
-              ? {
-                  ...app.spec.syncPolicy,
-                  automated: {
-                    prune: false,
-                    selfHeal: false,
-                  },
-                }
-              : {
-                  ...app.spec.syncPolicy,
-                  automated: undefined,
+        spec: {
+          ...app.spec,
+          syncPolicy: checked
+            ? {
+                ...app.spec.syncPolicy,
+                automated: {
+                  prune: false,
+                  selfHeal: false,
                 },
-          },
+              }
+            : {
+                ...app.spec.syncPolicy,
+                automated: undefined,
+              },
         },
       })
       toast.success(checked ? 'Auto-sync enabled' : 'Auto-sync disabled', {
@@ -360,7 +358,7 @@ export function ApplicationDetailPage() {
                 <Switch
                   checked={!!app.spec?.syncPolicy?.automated}
                   onCheckedChange={handleToggleAutoSync}
-                  disabled={updateMutation.isPending}
+                  disabled={updateSpecMutation.isPending}
                 />
               </div>
 


### PR DESCRIPTION
## Summary

- Fixed 403 Forbidden error when toggling auto-sync
- Added foundation for comprehensive application settings panel

## Changes

### Auto-sync Toggle Fix
**Problem**: ArgoCD was rejecting spec updates with 403 Forbidden error

**Root Cause**: We were sending a partial application object (only the `spec` field) to the full application update endpoint (`PUT /api/v1/applications/{name}`). ArgoCD requires either:
- Complete application object (metadata + spec + status) to the full endpoint
- Only the spec object to the dedicated `/spec` endpoint

**Solution**: 
- Added `updateApplicationSpec()` API function using `PUT /api/v1/applications/{name}/spec`
- Added `useUpdateApplicationSpec()` React Query hook
- Updated component to use spec-only updates
- Researched ArgoCD's actual API patterns using argocd-research-specialist agent

### Service Layer (`src/services/applications.ts`)
- Added `ENDPOINTS.applicationSpec` endpoint definition
- Added `applicationsApi.updateApplicationSpec()` function
- Added `useUpdateApplicationSpec()` mutation hook
- Imported `ApplicationSpec` type

### UI Layer (`src/pages/application-detail.tsx`)
- Changed from `useUpdateApplication` to `useUpdateApplicationSpec`
- Updated `handleToggleAutoSync` to send only the spec object
- Fixed disabled state to use `updateSpecMutation.isPending`

### Mock Server (`mock-server.js`)
- Added `PUT /api/v1/applications/:name/spec` endpoint
- Updated mock applications to include `project` field and `syncPolicy`
- Mock endpoint logs spec updates for debugging
- Returns updated spec matching ArgoCD behavior

## Testing

- ✅ Auto-sync toggle works with mock server
- ✅ Auto-sync toggle works with real ArgoCD instance
- ✅ Spec updates persist correctly
- ✅ Toast notifications display on success/error
- ✅ ESLint passes
- ✅ TypeScript build passes

## Next Steps

This PR lays the foundation for a comprehensive application settings panel that will match ArgoCD UI's full settings capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)