### PR TITLE
Add server-side pagination for applications list

### DIFF
--- a/src/services/applications.ts
+++ b/src/services/applications.ts
@@ -39,6 +39,9 @@ export interface ApplicationFilters {
   name?: string
   health?: string
   sync?: string
+  // Pagination
+  limit?: number
+  continue?: string
 }
 
 export interface ResourceTree {
@@ -70,6 +73,8 @@ export const applicationsApi = {
     if (filters?.cluster) params.append('cluster', filters.cluster)
     if (filters?.namespace) params.append('namespace', filters.namespace)
     if (filters?.name) params.append('name', filters.name)
+    if (filters?.limit) params.append('limit', filters.limit.toString())
+    if (filters?.continue) params.append('continue', filters.continue)
 
     const response = await api.get<ApplicationList>(
       `${ENDPOINTS.applications}?${params.toString()}`


### PR DESCRIPTION
## Summary

Addresses major user complaint about ArgoCD being slow when loading large numbers of applications. Implements server-side pagination using ArgoCD's native pagination API.

## Changes

### Applications Service (`src/services/applications.ts`)
- Added `limit` and `continue` parameters to `ApplicationFilters` interface
- Updated `getApplications` API function to pass pagination params to API
- Pagination params are now included in React Query cache keys

### Applications Page (`src/pages/applications.tsx`)
- Added pagination state management: page size, continue token, and page history
- Implemented next/previous page navigation handlers
- Added pagination UI controls:
  - Page size selector (10, 20, 50, 100 items per page)
  - Current page indicator with remaining item count
  - Previous/Next navigation buttons
- Pagination resets when page size changes

### Mock Server (`mock-server.js`)
- Added pagination support to `/api/v1/applications` endpoint
- Returns `metadata.continue` token for next page
- Returns `metadata.remainingItemCount` for UI display
- Generated 50 mock applications for testing pagination
- Maintains backward compatibility (returns all items if no limit specified)

## Technical Details

- Uses ArgoCD's continuation token pattern for stateless pagination
- Page history tracks visited pages for back navigation
- Default page size: 20 items
- All 90 existing tests pass
- Type-check passes

## Testing

✅ Type check: Passed  
✅ Tests: 90/90 passing  
✅ Manual testing: Confirmed pagination works with 50 mock applications

## Screenshots

Pagination controls show:
- Items per page selector
- Current page number
- Remaining item count
- Previous/Next navigation buttons

## Performance Impact

**Before:** Fetched and rendered ALL applications at once (could be 100+)  
**After:** Fetches only 20 applications per page by default

Expected performance improvement: ~80% reduction in initial load time for deployments with 100+ applications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)