### PR TITLE
feat: add click-to-component plugin for dev workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.45.0",
         "vite": "^7.1.7",
+        "vite-plugin-react-click-to-component": "^4.1.0",
         "vitest": "^3.2.4"
       }
     },
@@ -8429,6 +8430,17 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-plugin-react-click-to-component": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-click-to-component/-/vite-plugin-react-click-to-component-4.1.0.tgz",
+      "integrity": "sha512-zNsBtfafMAQvzOphHwDdfSuGY6LOaBbmN3+ambTElxgBUPS7sEi8SS+E9y3TF4jt+PlQk+y6ezGdfU640epKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.3.1 || ^19.0.0",
+        "vite": "^7"
       }
     },
     "node_modules/vite/node_modules/fdir": {


### PR DESCRIPTION
## Summary
- Adds `vite-plugin-react-click-to-component` for improved developer experience
- Enables Option+Click (Alt+Click) on React components to open them directly in your editor
- Respects `EDITOR` environment variable for editor selection
- Defaults to VS Code if `EDITOR` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)