### PR TITLE
fix: update Claude workflow to use correct action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,28 +1,36 @@
-name: Claude Code Review
+name: Claude Code
 
 on:
   issue_comment:
     types: [created]
-
-permissions:
-  contents: read
-  pull-requests: write
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
-  claude-review:
-    name: Claude PR Review
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '@claude')
-
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 1
 
-      - name: Claude Code Review
-        uses: anthropics/claude-code-review-action@v1
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@beta
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Fixes the Claude Code GitHub Action to use the correct action name: `anthropics/claude-code-action@beta`
- Adds support for multiple trigger events (PR review comments, issues, PR reviews)
- Updates permissions and conditional logic to properly detect @claude mentions

## Why this fixes the issue
The original workflow was using `anthropics/claude-code-review-action@v1` which doesn't exist. The correct action is `anthropics/claude-code-action@beta`.

## Changes
- ✅ Changed action from `anthropics/claude-code-review-action@v1` to `anthropics/claude-code-action@beta`
- ✅ Added `pull_request_review_comment`, `issues`, and `pull_request_review` trigger events
- ✅ Updated permissions to include `id-token: write` for authentication
- ✅ Improved conditional logic to detect @claude across all event types
- ✅ Simplified checkout to `fetch-depth: 1` (matches working config)

## Test plan
- [ ] Merge this PR
- [ ] Comment `@claude` on a PR to verify the action runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)