### PR TITLE
fix: align Dockerfile with enterprise Helm chart refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN go mod download
 COPY backend/ ./
 
 # Build the Go binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o rbac-proxy main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o cased-backend main.go
 
 # ==============================================================================
 # Stage 4: Enterprise Image (Go + React + RBAC) - ENTERPRISE TIER
@@ -84,21 +84,21 @@ RUN apk --no-cache add ca-certificates
 WORKDIR /app
 
 # Copy Go binary from backend builder
-COPY --from=backend-builder /app/rbac-proxy /app/rbac-proxy
+COPY --from=backend-builder /app/cased-backend /app/cased-backend
 
 # Copy React build from frontend builder
 COPY --from=frontend-builder /app/dist /app/dist
 
 # Environment variables for configuration
-ENV PORT=8080
+ENV PORT=8081
 ENV ARGOCD_SERVER=http://argocd-server.argocd.svc.cluster.local:80
 
 # Expose port
-EXPOSE 8080
+EXPOSE 8081
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --quiet --tries=1 --spider http://localhost:8080/health || exit 1
+  CMD wget --quiet --tries=1 --spider http://localhost:8081/health || exit 1
 
 # Run the Go binary
-CMD ["/app/rbac-proxy"]
+CMD ["/app/cased-backend"]


### PR DESCRIPTION
## Summary

Fixes the enterprise Docker image to align with the Helm chart refactor that renamed all `rbac-proxy` components to `enterprise`.

## Changes

**Binary Naming:**
- Rename Go binary output: `rbac-proxy` → `cased-backend`
- Update CMD to run `/app/cased-backend`

**Port Configuration:**
- Change from port `8080` → `8081` to match Helm chart
- Update `ENV PORT=8081`
- Update `EXPOSE 8081`
- Update health check to use port `8081`

## Why This Fix Is Needed

The recent Helm chart refactor (PR #35) renamed everything from `rbac-proxy` to `enterprise`:
- Template files: `rbac-proxy-*` → `enterprise-*`
- Values.yaml: `rbacProxy` → `enterprise`
- Service/deployment names: `rbac-proxy` → `enterprise`
- Container port: `8081` (defined in `enterprise-deployment.yaml`)

However, the Dockerfile was not updated and still:
- Built binary as `rbac-proxy`
- Used port `8080`
- Ran `/app/rbac-proxy`

This caused a mismatch where Kubernetes would try to connect to port `8081` but the container was listening on `8080`.

## Impact

**Before (Broken):**
- Helm chart expects backend on port `8081`
- Docker image listens on port `8080`
- Health checks fail, pod never becomes ready

**After (Fixed):**
- Both Helm chart and Docker image use port `8081`
- Binary name matches new naming convention
- Pod becomes ready, services work correctly

## Testing

- [ ] Docker image builds successfully
- [ ] Enterprise deployment works via Helm
- [ ] Health check passes on port 8081
- [ ] Frontend can connect to backend on port 8081

## Related

- PR #35: Comprehensive audit trail with enterprise backend refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)