### PR TITLE
docs: add enterprise image authentication instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,23 @@ That's it! Access Cased CD at `http://localhost:8080` (via port-forward) or conf
 **Prerequisites:**
 - Existing ArgoCD installation (v2.0+)
 - Kubernetes cluster with default StorageClass (for audit log PVC)
+- Enterprise credentials for accessing the private container image
+
+**Authentication:**
+
+The enterprise backend image (`ghcr.io/cased/cased-cd-enterprise`) is private and requires authentication. Enterprise customers need to create an imagePullSecret:
+
+```bash
+# Create a GitHub Personal Access Token with read:packages scope
+# Then create the secret in your cluster:
+kubectl create secret docker-registry cased-enterprise \
+  --docker-server=ghcr.io \
+  --docker-username=YOUR_GITHUB_USERNAME \
+  --docker-password=YOUR_GITHUB_TOKEN \
+  --namespace=argocd
+```
+
+**Note:** This authentication mechanism may change in future releases to simplify deployment.
 
 **Deploy with Helm:**
 
@@ -129,7 +146,8 @@ helm repo update
 helm install cased-cd cased/cased-cd \
   --namespace argocd \
   --set enterprise.enabled=true \
-  --set enterprise.persistence.size=10Gi
+  --set enterprise.persistence.size=10Gi \
+  --set imagePullSecrets[0].name=cased-enterprise
 ```
 
 **What gets deployed:**

--- a/chart/templates/enterprise-deployment.yaml
+++ b/chart/templates/enterprise-deployment.yaml
@@ -18,6 +18,10 @@ spec:
         {{- include "cased-cd.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: enterprise
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "cased-cd.serviceAccountName" . }}
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Summary

Documents how enterprise customers authenticate to pull the private `ghcr.io/cased/cased-cd-enterprise` container image.

## Changes

**README Documentation:**
- Added "Authentication" section under Enterprise Installation
- Explains that the enterprise image is private and requires credentials
- Provides step-by-step instructions for creating imagePullSecret
- Includes note that authentication mechanism may change in future releases

**Helm Chart Update:**
- Added `imagePullSecrets` support to enterprise deployment template
- Uses existing `imagePullSecrets` value from values.yaml
- Allows Kubernetes to authenticate when pulling the private image

## How It Works

**For Enterprise Customers:**

1. Create a GitHub Personal Access Token with `read:packages` scope
2. Create the imagePullSecret in their cluster:
   ```bash
   kubectl create secret docker-registry cased-enterprise \
     --docker-server=ghcr.io \
     --docker-username=GITHUB_USERNAME \
     --docker-password=GITHUB_TOKEN \
     --namespace=argocd
   ```
3. Reference the secret when installing:
   ```bash
   helm install cased-cd cased/cased-cd \
     --set enterprise.enabled=true \
     --set imagePullSecrets[0].name=cased-enterprise
   ```

**For Cased (package management):**
1. Set `cased-cd-enterprise` package to **Private** in GitHub settings
2. Grant access to enterprise customers by adding their GitHub org/user to the package
3. No license validation or additional complexity needed

## Why This Approach

✅ **Simple** - Uses GitHub's built-in package access control  
✅ **No extra services** - No license validation backend needed  
✅ **Familiar** - Standard Kubernetes imagePullSecrets pattern  
✅ **Flexible** - Can change to different auth mechanism later (noted in docs)  

## Future Considerations

The docs include a note that this authentication mechanism may change in future releases. Potential future approaches:
- Public image with license key validation
- Commercial Docker registry (Docker Hub, Quay.io)
- OCI Helm charts with embedded authentication

For MVP, this GitHub-based approach is the simplest for shipping soon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)