### PR TITLE
feat: add version number to login page footer

### DIFF
--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -139,6 +139,9 @@ function LoginPage() {
             <p className="text-xs text-neutral-500">
               Powered by ArgoCD • Built by Cased
             </p>
+            <p className="text-xs text-neutral-400 mt-1">
+              v{import.meta.env.PACKAGE_VERSION || '0.1.6'}
+            </p>
           </div>
         </div>
       </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,16 @@ import react from '@vitejs/plugin-react'
 import { reactClickToComponent } from 'vite-plugin-react-click-to-component'
 import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
 import path from 'path'
+import { readFileSync } from 'fs'
+
+// Read version from package.json
+const packageJson = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    'import.meta.env.PACKAGE_VERSION': JSON.stringify(packageJson.version),
+  },
   plugins: [
     TanStackRouterVite(),
     react(),


### PR DESCRIPTION
## Summary

Add the application version number to the login page footer for better version visibility and troubleshooting.

## Changes

- **Login Page**: Add version display below the existing footer text
- **Vite Config**: Inject  from package.json at build time using Vite's  option
- **Styling**: Version shown in lighter gray (neutral-400) below the main footer text

## UI Preview

The login page now shows:


## Benefits

- Users can easily see which version they're running
- Helpful for support and troubleshooting
- Version automatically updates with package.json

## Test Plan

- [x] Version displays correctly on login page
- [x] Version is read from package.json (0.1.6)
- [x] Styling matches the page design (subtle, not intrusive)
- [x] Dev server works with new vite config

🤖 Generated with [Claude Code](https://claude.com/claude-code)