### PR TITLE
refactor: use Link component for breadcrumb navigation

### DIFF
--- a/src/components/ui/page-title.tsx
+++ b/src/components/ui/page-title.tsx
@@ -3,5 +3,5 @@ interface PageTitleProps {
 }
 
 export function PageTitle({ children }: PageTitleProps) {
-  return <h1 className="text-lg font-semibold text-foreground">{children}</h1>;
+  return <h1 className="text-lg font-medium text-foreground">{children}</h1>;
 }

--- a/src/routes/_authenticated/applications.$name.tsx
+++ b/src/routes/_authenticated/applications.$name.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, useNavigate, useParams, useRouterState } from '@tanstack/react-router'
+import { createFileRoute, Link, Outlet, useNavigate, useParams, useRouterState } from '@tanstack/react-router'
 import { useState, useEffect } from 'react'
 import {
   IconCircleForward,
@@ -215,14 +215,12 @@ function ApplicationDetailLayout() {
             <Breadcrumb>
               <BreadcrumbList>
                 <BreadcrumbItem>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-auto p-0 text-sm text-neutral-600 dark:text-neutral-400 hover:text-black dark:hover:text-white"
-                    onClick={() => navigate({ to: '/applications' })}
+                  <Link
+                    to="/applications"
+                    className="text-sm text-neutral-600 dark:text-neutral-400 hover:text-black dark:hover:text-white"
                   >
                     Applications
-                  </Button>
+                  </Link>
                 </BreadcrumbItem>
                 <BreadcrumbSeparator>
                   <IconChevronRight size={14} />


### PR DESCRIPTION
## Summary

- Replace Button with TanStack Router Link component in application detail breadcrumb
- Update PageTitle font weight from semibold to medium for consistency

## Changes

### Breadcrumb Navigation
Replaced the Button component with onClick handler to a proper Link component for the "Applications" breadcrumb link. This provides:
- Better navigation semantics (proper anchor element)
- Improved accessibility (screen readers identify it as a link)
- Enhanced UX (right-click context menu, cmd+click to open in new tab, etc.)
- Automatic prefetching and client-side routing via TanStack Router

### PageTitle Font Weight
Updated font weight from `semibold` to `medium` for visual consistency across the UI.

## Test plan

- [ ] Navigate to an application detail page
- [ ] Click the "Applications" breadcrumb link - should navigate back to applications list
- [ ] Right-click the breadcrumb link - should show browser context menu
- [ ] Cmd+click (Mac) or Ctrl+click (Windows) - should open in new tab
- [ ] Verify PageTitle font weight looks consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)