### PR TITLE
docs: migrate enterprise distribution to registry.cased.com

### DIFF
--- a/manifests/install-enterprise.yaml
+++ b/manifests/install-enterprise.yaml
@@ -141,6 +141,8 @@ spec:
         app.kubernetes.io/instance: cased-cd
     spec:
       serviceAccountName: cased-cd
+      imagePullSecrets:
+        - name: cased-cd-registry
       securityContext:
         fsGroup: 101
         runAsNonRoot: true
@@ -222,6 +224,8 @@ spec:
         app.kubernetes.io/component: enterprise
     spec:
       serviceAccountName: cased-cd
+      imagePullSecrets:
+        - name: cased-cd-registry
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -230,7 +234,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: enterprise
-          image: "ghcr.io/cased/cased-cd-enterprise:0.1.12"
+          image: "registry.cased.com/cased/cased-cd-enterprise:0.1.12"
           imagePullPolicy: IfNotPresent
           command: ["/app/cased-backend"]
           env:


### PR DESCRIPTION
Replace GitHub fine-grained PAT distribution with registry proxy approach:

- Update ENTERPRISE.md to document registry.cased.com proxy
- Replace GitHub PAT instructions with management commands
- Update install-enterprise.yaml to use registry.cased.com
- Add imagePullSecrets to both deployments
- Update troubleshooting guides with new registry endpoints
- Document new token management commands (create, list, revoke, instructions)

Benefits:
- No need to create GitHub PATs manually
- Instant token revocation
- Full audit trail of all image pulls
- Better security isolation (customers never get GitHub credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)