### PR TITLE
fix: use nginx variable for dynamic DNS resolution

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -54,6 +54,14 @@ http {
         root /usr/share/nginx/html;
         index index.html;
 
+        # Resolver for dynamic upstream resolution
+        # This allows nginx to resolve DNS at request time instead of startup
+        resolver 127.0.0.11 valid=10s ipv6=off;
+        resolver_timeout 5s;
+
+        # Set proxy target as a variable (enables runtime DNS resolution)
+        set $proxy_target "${PROXY_TARGET}";
+
         # Custom error pages
         error_page 429 /429.html;
         location = /429.html {
@@ -123,7 +131,7 @@ http {
             }
 
             # Proxy to backend (enterprise backend or ArgoCD directly)
-            proxy_pass ${PROXY_TARGET}/api/v1/session;
+            proxy_pass $proxy_target/api/v1/session;
             proxy_http_version 1.1;
 
             # SSL settings for HTTPS backends (allows self-signed certs)
@@ -164,7 +172,7 @@ http {
             }
 
             # Proxy to backend (enterprise backend or ArgoCD directly)
-            proxy_pass ${PROXY_TARGET}/api/;
+            proxy_pass $proxy_target/api/;
             proxy_http_version 1.1;
 
             # SSL settings for HTTPS backends (allows self-signed certs)


### PR DESCRIPTION
Fixes CI test failures where nginx couldn't resolve upstream hosts at startup.

**Problem:**
Nginx was trying to resolve upstream hostnames (like `test-argocd`) at startup, which failed in test environments where those hosts don't exist.

**Solution:**
- Use nginx variable ($proxy_target) for dynamic DNS resolution
- Add resolver directive to enable runtime DNS lookups
- Nginx now resolves hostnames at request time instead of startup

**Changes:**
- Update nginx.conf.template to use $proxy_target variable
- Update docker integration tests to check for variable usage
- Resolves startup failures in environments without DNS

This allows containers to start successfully even when upstream hosts are not immediately resolvable.