### PR TITLE
docs: fix registry proxy documentation for enterprise customers

### DIFF
--- a/ENTERPRISE.md
+++ b/ENTERPRISE.md
@@ -164,7 +164,7 @@ kubectl create secret docker-registry cased-cd-registry \
 
 # Step 2: Install with Helm
 helm install cased-cd \
-  https://cased.github.io/cased-cd/cased-cd-0.1.14.tgz \
+  https://cased.github.io/cased-cd/cased-cd-0.1.15.tgz \
   --namespace argocd \
   --set enterprise.enabled=true \
   --set enterprise.auditTrail.enabled=true \

--- a/README.md
+++ b/README.md
@@ -192,19 +192,18 @@ For other platforms, common storage classes are:
 
 **Authentication:**
 
-The enterprise backend image (`ghcr.io/cased/cased-cd-enterprise`) is private and requires authentication. Enterprise customers need to create an imagePullSecret:
+The enterprise backend image is distributed via our private registry at `registry.cased.com`. Enterprise customers receive a unique access token from Cased support and need to create an imagePullSecret:
 
 ```bash
-# Create a GitHub Personal Access Token with read:packages scope
-# Then create the secret in your cluster:
-kubectl create secret docker-registry cased-enterprise \
-  --docker-server=ghcr.io \
-  --docker-username=YOUR_GITHUB_USERNAME \
-  --docker-password=YOUR_GITHUB_TOKEN \
+# Create the secret with credentials provided by Cased support
+kubectl create secret docker-registry cased-cd-registry \
+  --docker-server=registry.cased.com \
+  --docker-username=YOUR_CUSTOMER_NAME \
+  --docker-password=YOUR_CUSTOMER_TOKEN \
   --namespace=argocd
 ```
 
-**Note:** This authentication mechanism may change in future releases to simplify deployment.
+Contact support@cased.com to receive your enterprise access credentials.
 
 **Deploy with Helm:**
 
@@ -217,8 +216,9 @@ helm repo update
 helm install cased-cd cased/cased-cd \
   --namespace argocd \
   --set enterprise.enabled=true \
+  --set enterprise.image.repository=registry.cased.com/cased/cased-cd-enterprise \
   --set enterprise.persistence.size=10Gi \
-  --set imagePullSecrets[0].name=cased-enterprise
+  --set imagePullSecrets[0].name=cased-cd-registry
 ```
 
 **What gets deployed:**
@@ -283,11 +283,11 @@ kubectl port-forward -n argocd svc/cased-cd 8080:80
 
 **Enterprise (with audit trail and RBAC features):**
 ```bash
-# First, create the imagePullSecret for the private enterprise image
-kubectl create secret docker-registry cased-enterprise \
-  --docker-server=ghcr.io \
-  --docker-username=YOUR_GITHUB_USERNAME \
-  --docker-password=YOUR_GITHUB_TOKEN \
+# First, create the imagePullSecret with credentials from Cased support
+kubectl create secret docker-registry cased-cd-registry \
+  --docker-server=registry.cased.com \
+  --docker-username=YOUR_CUSTOMER_NAME \
+  --docker-password=YOUR_CUSTOMER_TOKEN \
   --namespace=argocd
 
 # Apply the enterprise manifests
@@ -299,7 +299,7 @@ kubectl port-forward -n argocd svc/cased-cd 8080:80
 
 1. **Disable audit trails** (simplest for testing):
    ```bash
-   helm install cased-cd https://cased.github.io/cased-cd/cased-cd-0.1.14.tgz \
+   helm install cased-cd https://cased.github.io/cased-cd/cased-cd-0.1.15.tgz \
      --namespace argocd \
      --set enterprise.enabled=true \
      --set enterprise.auditTrail.enabled=false \

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -39,19 +39,19 @@ kubectl describe pod -n argocd -l app.kubernetes.io/component=enterprise | grep 
 
 **Error:**
 ```
-Failed to pull image "docker.io/casedimages/cased-cd-enterprise:0.1.15":
+Failed to pull image "registry.cased.com/cased/cased-cd-enterprise:0.1.15":
 rpc error: code = Unknown desc = failed to pull and unpack image:
-failed to resolve reference "docker.io/casedimages/cased-cd-enterprise:0.1.15":
+failed to resolve reference "registry.cased.com/cased/cased-cd-enterprise:0.1.15":
 pull access denied, repository does not exist or may require authentication
 ```
 
 **Fix:**
 ```bash
-# Create the secret with your DockerHub token
+# Create the secret with your customer token (provided by Cased support)
 kubectl create secret docker-registry cased-cd-registry \
-  --docker-server=docker.io \
-  --docker-username=casedimages \
-  --docker-password=YOUR_TOKEN_HERE \
+  --docker-server=registry.cased.com \
+  --docker-username="YOUR_CUSTOMER_NAME" \
+  --docker-password="YOUR_CUSTOMER_TOKEN" \
   -n argocd
 
 # Verify it exists
@@ -69,6 +69,7 @@ kubectl get secrets -n argocd | grep docker-registry
 helm upgrade cased-cd cased-cd/cased-cd \
   --namespace argocd \
   --set enterprise.enabled=true \
+  --set enterprise.image.repository=registry.cased.com/cased/cased-cd-enterprise \
   --set imagePullSecrets[0].name=cased-cd-registry  # ← Must match secret name
 ```
 
@@ -77,8 +78,8 @@ helm upgrade cased-cd cased-cd/cased-cd \
 **Check token validity:**
 ```bash
 # Try pulling the image manually
-docker login docker.io -u casedimages -p YOUR_TOKEN_HERE
-docker pull docker.io/casedimages/cased-cd-enterprise:0.1.15
+echo "YOUR_CUSTOMER_TOKEN" | docker login registry.cased.com -u "YOUR_CUSTOMER_NAME" --password-stdin
+docker pull registry.cased.com/cased/cased-cd-enterprise:0.1.15
 ```
 
 If this fails, contact support@cased.com for a new token.


### PR DESCRIPTION
- Update TROUBLESHOOTING.md to use registry.cased.com instead of docker.io
- Update README.md to use correct registry and secret name
- Update version references from 0.1.14 to 0.1.15
- Add clear instructions that credentials come from Cased support

Fixes critical documentation errors that would send customers to non-existent registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)