### PR TITLE
Community user tracking with welcome modal

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -88,11 +88,11 @@ http {
         # - style-src 'self' 'unsafe-inline': Allow inline styles (needed for Tailwind)
         # - img-src 'self' data: blob:: Allow images from same origin, data URIs, and blobs
         # - font-src 'self' data:: Allow fonts from same origin and data URIs
-        # - connect-src 'self': Only allow API calls to same origin
+        # - connect-src 'self' https://api.cased.com: Allow API calls to same origin and Cased API (for community user tracking)
         # - frame-ancestors 'none': Prevent embedding in iframes
         # - base-uri 'self': Restrict base tag to same origin
         # - form-action 'self': Only allow forms to submit to same origin
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' https://api.cased.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
 
         # Health check endpoint
         location /health {

--- a/src/components/welcome-modal.test.tsx
+++ b/src/components/welcome-modal.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { WelcomeModal } from './welcome-modal'
+
+describe('WelcomeModal', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.clearAllMocks()
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should not render modal if already shown', () => {
+    localStorage.setItem('cased_cd_welcome_shown', 'submitted')
+    localStorage.setItem('argocd_token', 'test-token')
+
+    render(<WelcomeModal />)
+
+    expect(screen.queryByText(/Welcome to Cased CD/i)).not.toBeInTheDocument()
+  })
+
+  it('should not render modal if not authenticated', () => {
+    render(<WelcomeModal />)
+
+    expect(screen.queryByText(/Welcome to Cased CD/i)).not.toBeInTheDocument()
+  })
+
+  it('should render modal for community edition when authenticated and not shown before', async () => {
+    localStorage.setItem('argocd_token', 'test-token')
+
+    render(<WelcomeModal />)
+
+    // Wait for modal to appear (1 second delay in component)
+    await waitFor(() => {
+      expect(screen.getByText(/Welcome to Cased CD/i)).toBeInTheDocument()
+    }, { timeout: 3000 })
+  })
+
+  it('should allow skipping the modal', async () => {
+    localStorage.setItem('argocd_token', 'test-token')
+
+    render(<WelcomeModal />)
+
+    // Wait for modal to appear
+    await waitFor(() => {
+      expect(screen.getByText(/Welcome to Cased CD/i)).toBeInTheDocument()
+    }, { timeout: 3000 })
+
+    const skipButton = screen.getByRole('button', { name: /skip/i })
+    await userEvent.click(skipButton)
+
+    expect(localStorage.getItem('cased_cd_welcome_shown')).toBe('skipped')
+    expect(screen.queryByText(/Welcome to Cased CD/i)).not.toBeInTheDocument()
+  })
+
+  it('should submit form data successfully', async () => {
+    localStorage.setItem('argocd_token', 'test-token')
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 'ok' }),
+    })
+    global.fetch = mockFetch
+
+    render(<WelcomeModal />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Welcome to Cased CD/i)).toBeInTheDocument()
+    }, { timeout: 3000 })
+
+    // Fill in form
+    const nameInput = screen.getByLabelText(/name or organization/i)
+    const emailInput = screen.getByLabelText(/email/i)
+
+    await userEvent.type(nameInput, 'Test User')
+    await userEvent.type(emailInput, 'test@example.com')
+
+    // Submit
+    const submitButton = screen.getByRole('button', { name: /submit/i })
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.cased.com/api/v1/community/welcome',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Community-Token': 'ccd_community_v1_public_k7m2x9p4n8',
+          },
+          body: JSON.stringify({
+            name: 'Test User',
+            email: 'test@example.com',
+          }),
+        })
+      )
+      expect(localStorage.getItem('cased_cd_welcome_shown')).toBe('submitted')
+    })
+  })
+
+  it('should handle submission errors gracefully', async () => {
+    localStorage.setItem('argocd_token', 'test-token')
+
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'))
+    global.fetch = mockFetch
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<WelcomeModal />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Welcome to Cased CD/i)).toBeInTheDocument()
+    }, { timeout: 3000 })
+
+    const submitButton = screen.getByRole('button', { name: /submit/i })
+    await userEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(localStorage.getItem('cased_cd_welcome_shown')).toBe('error')
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to submit welcome data:',
+        expect.any(Error)
+      )
+    })
+
+    consoleSpy.mockRestore()
+  })
+
+  // Note: Skipping select test due to JSDOM limitations with Radix UI Select
+  // The select component uses hasPointerCapture which is not available in JSDOM
+  it.skip('should allow selecting use case', async () => {
+    // Test skipped - Radix UI Select requires DOM APIs not available in JSDOM
+  })
+
+  it('should disable inputs while submitting', async () => {
+    localStorage.setItem('argocd_token', 'test-token')
+
+    // Mock a slow response
+    const mockFetch = vi.fn().mockImplementation(
+      () => new Promise(resolve => setTimeout(() => resolve({
+        ok: true,
+        json: async () => ({ status: 'ok' }),
+      }), 100))
+    )
+    global.fetch = mockFetch
+
+    render(<WelcomeModal />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Welcome to Cased CD/i)).toBeInTheDocument()
+    }, { timeout: 3000 })
+
+    const submitButton = screen.getByRole('button', { name: /submit/i })
+    await userEvent.click(submitButton)
+
+    // Check that button shows "Submitting..." and is disabled
+    expect(screen.getByText(/submitting/i)).toBeInTheDocument()
+    expect(submitButton).toBeDisabled()
+
+    // Wait for submission to complete
+    await waitFor(() => {
+      expect(localStorage.getItem('cased_cd_welcome_shown')).toBe('submitted')
+    })
+  })
+})

--- a/src/components/welcome-modal.tsx
+++ b/src/components/welcome-modal.tsx
@@ -1,0 +1,183 @@
+import { useState, useEffect } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+
+const STORAGE_KEY = 'cased_cd_welcome_shown'
+
+interface WelcomeData {
+  name?: string
+  email?: string
+  useCase?: string
+}
+
+export function WelcomeModal() {
+  const [open, setOpen] = useState(false)
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [useCase, setUseCase] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Only show for community edition
+  const isCommunity = import.meta.env.VITE_IS_ENTERPRISE !== 'true'
+
+  useEffect(() => {
+    // Only show if:
+    // 1. It's the community edition
+    // 2. User hasn't seen the modal before
+    // 3. User is authenticated (has a token)
+    const hasSeenWelcome = localStorage.getItem(STORAGE_KEY)
+    const hasToken = localStorage.getItem('argocd_token')
+
+    if (isCommunity && !hasSeenWelcome && hasToken) {
+      // Show modal after a short delay for better UX
+      const timer = setTimeout(() => {
+        setOpen(true)
+      }, 1000)
+      return () => clearTimeout(timer)
+    }
+  }, [isCommunity])
+
+  const handleSkip = () => {
+    localStorage.setItem(STORAGE_KEY, 'skipped')
+    setOpen(false)
+  }
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true)
+
+    const data: WelcomeData = {
+      name: name.trim() || undefined,
+      email: email.trim() || undefined,
+      useCase: useCase || undefined,
+    }
+
+    try {
+      // Send to Cased backend at api.cased.com
+      // Note: The community token below is PUBLIC (not a secret). It's embedded in all
+      // community edition builds and just ensures requests come from Cased CD installs.
+      await fetch('https://api.cased.com/api/v1/community/welcome', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Community-Token': 'ccd_community_v1_public_k7m2x9p4n8', // Public token
+        },
+        body: JSON.stringify(data),
+      })
+      localStorage.setItem(STORAGE_KEY, 'submitted')
+      setOpen(false)
+    } catch (error) {
+      // If it fails, just mark as shown and close
+      // We don't want to block the user if the endpoint fails
+      console.error('Failed to submit welcome data:', error)
+      localStorage.setItem(STORAGE_KEY, 'error')
+      setOpen(false)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (!isCommunity) {
+    return null
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle className="text-2xl">Welcome to Cased CD! 👋</DialogTitle>
+          <DialogDescription className="text-base pt-2">
+            Thanks for trying out Cased CD Community Edition! We'd love to know a bit about
+            how you're using it. This is completely optional and helps us improve the project.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name or Organization (optional)</Label>
+            <Input
+              id="name"
+              placeholder="e.g., John Doe or Acme Corp"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="email">Email (optional)</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="your@email.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={isSubmitting}
+            />
+            <p className="text-xs text-muted-foreground">
+              We'll only use this to send occasional product updates (you can unsubscribe anytime)
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="useCase">How are you planning to use Cased CD? (optional)</Label>
+            <Select value={useCase} onValueChange={setUseCase} disabled={isSubmitting}>
+              <SelectTrigger id="useCase">
+                <SelectValue placeholder="Select a use case..." />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="personal">Personal Project</SelectItem>
+                <SelectItem value="startup">Startup</SelectItem>
+                <SelectItem value="small-business">Small Business</SelectItem>
+                <SelectItem value="enterprise">Enterprise</SelectItem>
+                <SelectItem value="evaluation">Evaluating for Work</SelectItem>
+                <SelectItem value="learning">Learning/Education</SelectItem>
+                <SelectItem value="other">Other</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-950">
+            <p className="text-xs text-blue-900 dark:text-blue-100">
+              ℹ️ Your privacy matters. We don't collect any data from your ArgoCD deployments or
+              applications. This is just to understand our community better.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleSkip}
+            disabled={isSubmitting}
+          >
+            Skip
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Submitting...' : 'Submit'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/pages/help.tsx
+++ b/src/pages/help.tsx
@@ -322,7 +322,7 @@ export function HelpPage() {
                 </a>
               </div>
               <div className="text-right">
-                <div className="text-lg font-semibold text-black dark:text-white font-mono">v0.1.4</div>
+                <div className="text-lg font-semibold text-black dark:text-white font-mono">v0.2.9</div>
                 <div className="text-[11px] text-neutral-500 mt-0.5">Latest</div>
               </div>
             </div>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -201,6 +201,34 @@ export function SettingsPage() {
             </Card>
           </div>
 
+          {/* Development Section (localhost only) */}
+          {isLocalCluster && (
+            <div className="mt-6">
+              <h2 className="text-sm font-semibold text-black dark:text-white mb-3">
+                Development
+              </h2>
+              <Card className="border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-950 shadow-none">
+                <CardHeader className="p-4">
+                  <CardTitle className="text-sm">Testing</CardTitle>
+                  <CardDescription className="text-xs">
+                    Development tools (only visible on local clusters)
+                  </CardDescription>
+                </CardHeader>
+                <CardContent className="p-4 pt-0">
+                  <button
+                    onClick={() => {
+                      localStorage.removeItem('cased_cd_welcome_shown');
+                      window.location.reload();
+                    }}
+                    className="px-3 py-1.5 text-xs font-medium rounded-md border bg-white dark:bg-neutral-900 border-neutral-200 dark:border-neutral-800 text-neutral-600 dark:text-neutral-400 hover:bg-neutral-50 dark:hover:bg-neutral-800 transition-colors"
+                  >
+                    Reset Welcome Modal
+                  </button>
+                </CardContent>
+              </Card>
+            </div>
+          )}
+
       </PageContent>
     </div>
   );

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -21,7 +21,6 @@ import { Route as AuthenticatedGpgkeysRouteImport } from './routes/_authenticate
 import { Route as AuthenticatedClustersRouteImport } from './routes/_authenticated/clusters'
 import { Route as AuthenticatedCertificatesRouteImport } from './routes/_authenticated/certificates'
 import { Route as AuthenticatedApplicationsRouteImport } from './routes/_authenticated/applications'
-import { Route as AuthenticatedAccountsRouteImport } from './routes/_authenticated/accounts'
 import { Route as AuthenticatedApplicationsIndexRouteImport } from './routes/_authenticated/applications/index'
 import { Route as AuthenticatedApplicationsNameRouteImport } from './routes/_authenticated/applications.$name'
 import { Route as AuthenticatedApplicationsNameIndexRouteImport } from './routes/_authenticated/applications.$name/index'
@@ -94,11 +93,6 @@ const AuthenticatedApplicationsRoute =
     path: '/applications',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-const AuthenticatedAccountsRoute = AuthenticatedAccountsRouteImport.update({
-  id: '/accounts',
-  path: '/accounts',
-  getParentRoute: () => AuthenticatedRoute,
-} as any)
 const AuthenticatedApplicationsIndexRoute =
   AuthenticatedApplicationsIndexRouteImport.update({
     id: '/',
@@ -156,7 +150,6 @@ const AuthenticatedApplicationsNameDiffRoute =
 
 export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
-  '/accounts': typeof AuthenticatedAccountsRoute
   '/applications': typeof AuthenticatedApplicationsRouteWithChildren
   '/certificates': typeof AuthenticatedCertificatesRoute
   '/clusters': typeof AuthenticatedClustersRoute
@@ -179,7 +172,6 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/login': typeof LoginRoute
-  '/accounts': typeof AuthenticatedAccountsRoute
   '/certificates': typeof AuthenticatedCertificatesRoute
   '/clusters': typeof AuthenticatedClustersRoute
   '/gpgkeys': typeof AuthenticatedGpgkeysRoute
@@ -202,7 +194,6 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/login': typeof LoginRoute
-  '/_authenticated/accounts': typeof AuthenticatedAccountsRoute
   '/_authenticated/applications': typeof AuthenticatedApplicationsRouteWithChildren
   '/_authenticated/certificates': typeof AuthenticatedCertificatesRoute
   '/_authenticated/clusters': typeof AuthenticatedClustersRoute
@@ -227,7 +218,6 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/login'
-    | '/accounts'
     | '/applications'
     | '/certificates'
     | '/clusters'
@@ -250,7 +240,6 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/login'
-    | '/accounts'
     | '/certificates'
     | '/clusters'
     | '/gpgkeys'
@@ -272,7 +261,6 @@ export interface FileRouteTypes {
     | '__root__'
     | '/_authenticated'
     | '/login'
-    | '/_authenticated/accounts'
     | '/_authenticated/applications'
     | '/_authenticated/certificates'
     | '/_authenticated/clusters'
@@ -383,13 +371,6 @@ declare module '@tanstack/react-router' {
       path: '/applications'
       fullPath: '/applications'
       preLoaderRoute: typeof AuthenticatedApplicationsRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/accounts': {
-      id: '/_authenticated/accounts'
-      path: '/accounts'
-      fullPath: '/accounts'
-      preLoaderRoute: typeof AuthenticatedAccountsRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/applications/': {
@@ -509,7 +490,6 @@ const AuthenticatedApplicationsRouteWithChildren =
   )
 
 interface AuthenticatedRouteChildren {
-  AuthenticatedAccountsRoute: typeof AuthenticatedAccountsRoute
   AuthenticatedApplicationsRoute: typeof AuthenticatedApplicationsRouteWithChildren
   AuthenticatedCertificatesRoute: typeof AuthenticatedCertificatesRoute
   AuthenticatedClustersRoute: typeof AuthenticatedClustersRoute
@@ -523,7 +503,6 @@ interface AuthenticatedRouteChildren {
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
-  AuthenticatedAccountsRoute: AuthenticatedAccountsRoute,
   AuthenticatedApplicationsRoute: AuthenticatedApplicationsRouteWithChildren,
   AuthenticatedCertificatesRoute: AuthenticatedCertificatesRoute,
   AuthenticatedClustersRoute: AuthenticatedClustersRoute,

--- a/src/routes/_authenticated.tsx
+++ b/src/routes/_authenticated.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
 import { Layout } from '@/components/layout/layout'
+import { WelcomeModal } from '@/components/welcome-modal'
 
 export const Route = createFileRoute('/_authenticated')({
   beforeLoad: async () => {
@@ -18,5 +19,10 @@ export const Route = createFileRoute('/_authenticated')({
 })
 
 function AuthenticatedLayout() {
-  return <Layout />
+  return (
+    <>
+      <Layout />
+      <WelcomeModal />
+    </>
+  )
 }


### PR DESCRIPTION
## Summary

Add optional community user tracking to understand who is using Cased CD Community Edition. A welcome modal appears once on first login, allowing users to optionally share their name, email, and use case.

## Changes

### Frontend (cased-cd)
- ✅ New `WelcomeModal` component with comprehensive tests (7 passing tests)
- ✅ Only shows for community edition (not enterprise)
- ✅ Only shows once per user (tracked in localStorage)
- ✅ 1-second delay after login for better UX
- ✅ Skip or submit options
- ✅ Graceful error handling if API fails
- ✅ CSP policy updated to allow `api.cased.com`
- ✅ Dev reset button in Settings (local clusters only)
- ✅ Help page version updated to 0.2.9

### Backend (comet - separate PR #3177)
- ✅ `POST /api/v1/community/welcome` endpoint
- ✅ Rate limiting: 5 req/hour per IP + 1000 req/hour global
- ✅ Input sanitization (HTML escaping)
- ✅ IP anonymization for privacy (GDPR/CCPA compliant)
- ✅ CORS restricted to this endpoint only
- ✅ Slack notifications to #general

## Security Measures

- **Rate Limiting**: Prevents spam/DoS (5/hour per IP, 1000/hour global)
- **CORS**: Restricted to `/api/v1/community/welcome` only
- **Input Sanitization**: HTML escaping on all user inputs
- **IP Anonymization**: Last octet masked for privacy compliance
- **Origin Validation**: Logs unexpected origins for monitoring

## Test Plan

- [x] Lint passing
- [x] Type check passing
- [x] Unit tests passing (7/8 tests, 1 skipped due to JSDOM limitation)
- [x] Modal appears after first login on community edition
- [x] Modal doesn't appear on enterprise edition
- [x] Modal doesn't appear if already shown
- [x] Skip button works
- [x] Submit button works
- [x] Form data sent to api.cased.com correctly
- [x] Error handling works if API fails
- [x] Reset button works in Settings (local only)

## Screenshots

[User should see the welcome modal 1 second after login]

## Related PRs

- Backend PR: https://github.com/cased/comet/pull/3177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>